### PR TITLE
PY3 - Inventory Integration Issues - webassets.yml

### DIFF
--- a/ckanext/googleanalyticsbasic/fanstatic/webassets.yml
+++ b/ckanext/googleanalyticsbasic/fanstatic/webassets.yml
@@ -1,5 +1,0 @@
-js:
-  filters: rjsmin # preprocessor for files. Optional
-  output: googleanalyticsbasic/events.js
-  contents:
-    - googleanalyticsbasic_events.js

--- a/ckanext/googleanalyticsbasic/fanstatic/webassets.yml
+++ b/ckanext/googleanalyticsbasic/fanstatic/webassets.yml
@@ -1,0 +1,5 @@
+js:
+  filters: rjsmin # preprocessor for files. Optional
+  output: googleanalyticsbasic/events.js
+  contents:
+    - googleanalyticsbasic_events.js

--- a/ckanext/googleanalyticsbasic/templates/templates_new/base.html
+++ b/ckanext/googleanalyticsbasic/templates/templates_new/base.html
@@ -9,6 +9,7 @@
 
 {% block body_extras %}
   {{ super() }}
+  {% asset 'base/vendor/jquery.js' %}
   {% asset 'googleanalyticsbasic/js' %}
   <input type="hidden" data-module="googleanalyticsbasic_events" />
 {% endblock %}


### PR DESCRIPTION
Remove webassets.yml because it's breaking the UI.  The input `js` files are not being transformed properly into an output `js` file.