### PR TITLE
CKAN 2.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG CKAN_VERSION=2.9
+ARG CKAN_VERSION=2.10
 FROM openknowledge/ckan-dev:${CKAN_VERSION}
 
 COPY . /app

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CKAN_VERSION ?= 2.9
+CKAN_VERSION ?= 2.10
 COMPOSE_FILE ?= docker-compose.yml
 
 build: ## Build the docker containers

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ Installation
 
 This extension is compatible with these versions of CKAN.
 
-CKAN version | Compatibility
------------- | -------------
-<=2.8        | no
-2.9          | yes
+CKAN version  | Compatibility
+------------- | -------------
+<=2.8         | no
+2.9           | yes
+2.10          | yes
 
 ## Tests
 
@@ -58,7 +59,7 @@ To docker exec into the CKAN image, run:
 ### Testing
 
 They follow the guidelines for [testing CKAN
-extensions](https://docs.ckan.org/en/2.9/extensions/testing-extensions.html#testing-extensions).
+extensions](https://docs.ckan.org/en/2.10/extensions/testing-extensions.html#testing-extensions).
 
 To run the extension tests, start the containers with `make up`, then:
 

--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ In order to support multiple versions of CKAN, or even upgrade to new versions
 of CKAN, we support development and testing through the `CKAN_VERSION`
 environment variable.
 
-    $ make CKAN_VERSION=2.9 test
+    $ make CKAN_VERSION=2.10 test

--- a/ckanext/googleanalyticsbasic/plugin.py
+++ b/ckanext/googleanalyticsbasic/plugin.py
@@ -16,7 +16,6 @@ class GoogleAnalyticsBasicException(Exception):
 
 class GoogleAnalyticsBasicPlugin(p.SingletonPlugin):
     p.implements(p.IConfigurable, inherit=True)
-    p.implements(p.IRoutes, inherit=True)
     p.implements(p.IConfigurer, inherit=True)
     p.implements(p.ITemplateHelpers)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - .:/srv/app/src_extensions
       - ckan_storage:/var/lib/ckan
   db:
-    image: ckan/ckan-postgres-dev:${CKAN_VERSION}
+    image: ckan/ckan-postgres-dev:2.9
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
@@ -46,7 +46,7 @@ services:
   redis:
     image: redis:alpine
   solr:
-    image: ckan/ckan-solr-dev:${CKAN_VERSION}
+    image: ckan/ckan-solr-dev:2.9
     ports:
       - "8983:8983"
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-googleanalyticsbasic',
-    version='0.2.0',
+    version='0.2.1',
     description="Basic extension to add google analytics tracking code in page header",
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4209

Changes:
- `IRoutes` is deprecated and it wasn't doing anything for us since `CKAN 2.9.5`
- set default testing to 2.10